### PR TITLE
Create default virtualenv using pyenv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/d.barthelemy/.pyenv/versions/flask-app-generator/bin/python"
+}

--- a/flask-generator.py
+++ b/flask-generator.py
@@ -1,0 +1,91 @@
+import argparse as ap
+import jinja2
+import os
+import shutil
+import subprocess
+
+###
+# Virtual env
+# Comment gerer l'imports des views?
+# Gerer postgresql/mysql et sqlite connection
+###
+
+DB_CHOICES = ['mysql', 'postgresql', 'sqlite']
+
+def main():
+    parser = ap.ArgumentParser()
+    parser.add_argument('--name', help='Name of your project')
+    parser.add_argument('--db', help='Name of the database by default', required=False, choices=DB_CHOICES)
+    parser.add_argument('--directory', help="The base directory where you want to create your app", default="/tmp/")
+    parser.add_argument('--python', help="Define the python version", default="3.9.1")
+    args = parser.parse_args()  
+    directory = create_structure(args.name, args.directory)
+    create_virtualenv(directory, args)
+    create_requirements(directory, args)
+    create_run(directory, args)
+    create_python_files(directory, args)
+
+def create_structure(app_name: str, directory: str):
+    full_directory = os.path.join(directory, app_name)
+    if os.path.exists(full_directory):
+        shutil.rmtree(full_directory)
+    #if os.path.isdir(full_directory):
+    #    print(f"The directory {full_directory} already exists. Make a different choice")
+    #    shutil.rmtree(full_directory)
+    #    exit(-1)
+    shutil.copytree("templates/structure", full_directory)
+    return full_directory
+
+def create_requirements(directory: str, args: ap.Namespace):
+    file_loader = jinja2.FileSystemLoader('templates')
+    env = jinja2.Environment(loader=file_loader)
+    template = env.get_template('misc/requirements.fg')
+    output = template.render(database=args.db)
+    write_file(os.path.join(directory, "requirements.txt"), output)
+
+def create_virtualenv(directory: str, args: ap.Namespace):
+    print(f"pyenv virtualenv {args.python} {args.name}")
+    process = subprocess.Popen(f'pyenv virtualenv {args.python} {args.name}', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print('Creating virtual environment')
+    process.wait()
+    if process.returncode == 0:
+        print('Virtual environment created.')
+        write_file(os.path.join(directory, ".python-version"), args.name)
+        return
+    error = str(process.stderr.read())
+    if "already exists" in error:
+        print(f"Do you want to continue with the {args.name} virtualenv (yes or no)")
+        continue_with_venv = input(f"").lower()
+        if continue_with_venv in ["y", "yes"]:
+            write_file(os.path.join(directory, ".python-version"), args.name)
+            return
+    print(f"Virtual environment creation failed: {error}")
+    exit(-1)
+
+def create_run(directory: str, args: ap.Namespace):
+    file_loader = jinja2.FileSystemLoader('templates')
+    env = jinja2.Environment(loader=file_loader)
+    for _file in ['wsgy', 'app']:
+        template = env.get_template(f'misc/{_file}.fg')
+        output = template.render(database=args.db)
+        write_file(os.path.join(directory, f"{_file}.py"), output)
+
+def create_python_files(directory: str, args: ap.Namespace):
+    for _file in [
+        "config/__init__", "config/settings", 
+        "models/__init__", "views"
+    ]:
+        file_loader = jinja2.FileSystemLoader('templates')
+        env = jinja2.Environment(loader=file_loader)
+        template = env.get_template(f'python_files/{_file}.fg')
+        output = template.render(database=args.db)
+        write_file(os.path.join(directory, f"{_file}.py"), output)
+
+def write_file(filename: str, content: str):
+    print(filename)
+    with open(filename, "w") as f:
+        f.write(content)
+
+if __name__ == "__main__":
+    main()
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+argcomplete
+jinja2

--- a/templates/misc/app.fg
+++ b/templates/misc/app.fg
@@ -1,0 +1,23 @@
+import logging
+import os
+import config
+
+from flask import Flask
+from models import db
+
+
+logger = logging.getLogger()
+
+def create_app():
+    logger.info(f'Starting app in {config.APP_ENV} environment')
+    app = Flask(__name__)
+    app.config.from_object('config')
+
+    # initialize SQLAlchemy
+    db.init_app(app)
+    
+    return app
+    
+if __name__ == "__main__":
+    app = create_app()
+    app.run(host='0.0.0.0', debug=True)

--- a/templates/misc/requirements.fg
+++ b/templates/misc/requirements.fg
@@ -1,0 +1,9 @@
+flask
+{% if database == "mysql" -%}
+Flask-SQLAlchemy
+{%- endif %}
+{%- if database == "postgresql" -%}
+psycopg2
+Flask-Migrate
+Flask-SQLAlchemy
+{% endif %}

--- a/templates/misc/wsgy.fg
+++ b/templates/misc/wsgy.fg
@@ -1,0 +1,2 @@
+from app import create_app
+app = create_app()

--- a/templates/python_files/config/__init__.fg
+++ b/templates/python_files/config/__init__.fg
@@ -1,0 +1,21 @@
+import os
+import sys
+import config.settings
+
+# create settings object corresponding to specified env
+APP_ENV = os.environ.get('FLASK_ENV', 'DevelopmentConfig').title()
+_current = getattr(sys.modules['config.settings'], '{0}Config'.format(APP_ENV))()
+
+# copy attributes to the module for convenience
+for atr in [f for f in dir(_current) if not '__' in f]:
+    # environment can override anything
+    val = os.environ.get(atr, getattr(_current, atr))
+    setattr(sys.modules[__name__], atr, val)
+
+
+def as_dict():
+    res = {}
+    for atr in [f for f in dir(config) if not '__' in f]:
+        val = getattr(config, atr)
+        res[atr] = val
+    return res

--- a/templates/python_files/config/settings.fg
+++ b/templates/python_files/config/settings.fg
@@ -1,0 +1,27 @@
+import os
+
+class Config:
+    DEBUG = False
+    TEST = False
+    SECRET_KEY = os.getenv("SECRET_KEY", "this-is-the-default-key")
+    SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
+    STATIC_FOLDER = 'static'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SESSION_COOKIE_SECURE = False
+    {% if database == "mysql" %}
+    SQLALCHEMY_DATABASE_URI = ""
+    {% elif database == "postgresql" %}
+    SQLALCHEMY_DATABASE_URI = ""
+    {% elif database == "sqlite" %}
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///mydb.db'
+    {% endif %}
+
+class ProductionConfig(Config):
+    SESSION_COOKIE_SECURE = True
+
+class StagingConfig(Config):
+    DEBUG = True
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+    DEVELOPMENT = True

--- a/templates/python_files/models/__init__.fg
+++ b/templates/python_files/models/__init__.fg
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/templates/python_files/views.fg
+++ b/templates/python_files/views.fg
@@ -1,0 +1,5 @@
+from app import app
+
+@app.route('/')
+def hello():
+    return '<h1>Hello World</h1>'

--- a/test.py
+++ b/test.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+import argcomplete, argparse, requests, pprint
+
+def github_org_members(prefix, parsed_args, **kwargs):
+    resource = "https://api.github.com/orgs/{org}/members".format(org=parsed_args.organization)
+    return (member['login'] for member in requests.get(resource).json() if member['login'].startswith(prefix))
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--organization", help="GitHub organization")
+parser.add_argument("--member", help="GitHub member").completer = github_org_members
+
+argcomplete.autocomplete(parser)
+args = parser.parse_args()
+
+pprint.pprint(requests.get("https://api.github.com/users/{m}".format(m=args.member)).json())
+


### PR DESCRIPTION
When creating the folder, we need to create or use and exiting `virtualenv`.
Using the module `subprocess`, we can call `pyenv` to install a new virtualenv based on the `python version`  in parameter.

Creating the `.python-version` file ensures that the virtualenv can be activated and deactivated automatically